### PR TITLE
chore: avoid flakiness of size eviction test

### DIFF
--- a/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
+++ b/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
@@ -73,6 +73,11 @@ public abstract class ProviderTestBase {
 		// Add entries
 		for (int i = 0; i < 5; i++) {
 			cache.put(String.valueOf(i), i);
+
+			// Hint to LRU/LFU impls like ehcache that 0 should be selected for eviction
+			for (int j = 0; j < i; j++) {
+				cache.get(String.valueOf(i));
+			}
 		}
 
 		// Ensure the eldest entry was removed


### PR DESCRIPTION
to ensure element 0 is evicted, we access elements 1+ after insertion to hint to LRU/LFU implementation that 0 ought to be evicted when the final insertion occurs that is beyond the entry capacity of the map