### PR TITLE
chore: provider may not be null

### DIFF
--- a/core/src/main/java/io/github/xanthic/cache/core/CacheApiSettings.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/CacheApiSettings.java
@@ -128,6 +128,8 @@ public final class CacheApiSettings {
 				Class<? extends CacheProvider> clazz = Class.forName(providerClass).asSubclass(CacheProvider.class);
 				cacheApiSettings.registerCacheProvider(clazz, null); // lazy, init if needed
 				registered.incrementAndGet();
+			} catch (ClassNotFoundException cx) {
+				log.trace("Xanthic: Could not find optional cache provider " + providerClass);
 			} catch (Exception e) {
 				log.trace("Xanthic: Could not find optional cache provider " + providerClass, e);
 			}

--- a/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
@@ -57,7 +57,8 @@ public final class CacheApiSpec<K, V> implements ICacheSpec<K, V> {
 	 * @throws MisconfiguredCacheException if the cache settings are invalid (e.g., negative max size or expiry time)
 	 */
 	public void validate() {
-		Objects.requireNonNull(provider, "provider may not be null!");
+		if (provider == null)
+			throw new MisconfiguredCacheException("provider must not be null! You have not set a provider and no default cache provider was found - see https://xanthic.github.io/provider/ for instructions on how to add cache providers to your project.");
 
 		if (maxSize != null && maxSize < 0)
 			throw new MisconfiguredCacheException("maxSize may not be negative!");

--- a/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CacheApiSpec<K, V> implements ICacheSpec<K, V> {
 
-	@NotNull
 	private CacheProvider provider;
 
 	private Long maxSize;
@@ -44,6 +43,12 @@ public final class CacheApiSpec<K, V> implements ICacheSpec<K, V> {
 	private RemovalListener<K, V> removalListener;
 
 	private ScheduledExecutorService executor;
+
+	@NotNull
+	public CacheProvider provider() {
+		// noinspection ConstantConditions
+		return provider != null ? provider : CacheApiSettings.getInstance().getDefaultCacheProvider();
+	}
 
 	/**
 	 * Ensures the configured specification is valid.
@@ -81,7 +86,7 @@ public final class CacheApiSpec<K, V> implements ICacheSpec<K, V> {
 		spec.accept(data);
 
 		// noinspection ConstantConditions
-		if (data.provider() == null) {
+		if (data.provider == null) {
 			// set / init default cache provider if nothing is set
 			data.provider(CacheApiSettings.getInstance().getDefaultCacheProvider());
 			log.debug("No cache provider explicitly specified; cache defaults to {}!", data.provider.getClass().getCanonicalName());

--- a/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/CacheApiSpec.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CacheApiSpec<K, V> implements ICacheSpec<K, V> {
 
+	@NotNull
 	private CacheProvider provider;
 
 	private Long maxSize;

--- a/kotlin/src/main/kotlin/io/github/xanthic/cache/ktx/CacheApiSpecExtensions.kt
+++ b/kotlin/src/main/kotlin/io/github/xanthic/cache/ktx/CacheApiSpecExtensions.kt
@@ -21,7 +21,7 @@ fun <K, V> processSpec(init: CacheApiSpec<K, V>.() -> Unit): CacheApiSpec<K, V> 
 /**
  * @see io.github.xanthic.cache.api.ICacheSpec.provider
  */
-var <K, V> CacheApiSpec<K, V>.provider: CacheProvider?
+var <K, V> CacheApiSpec<K, V>.provider: CacheProvider
     get() = this.provider()
     set(value) {
         this.provider(value)


### PR DESCRIPTION
## Changes

- annotate CacheApiSpec.Provider as NotNull
- don't log the full ClassNotFound exception when looking for cache providers
