### PR TITLE
chore: only consider final infinispan updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,15 +14,21 @@
     "assignees": [],
     "branchPrefix": "chore/dependencies/",
     "digest": {
-      "enabled": false
+        "enabled": false
     },
     "labels": [
-      "dependencies"
+        "dependencies"
     ],
     "rebaseWhen": "behind-base-branch",
     "reviewers": ["iProdigy", "PhilippHeuer"],
     "vulnerabilityAlerts": {
-      "assignees": ["iProdigy", "PhilippHeuer"],
-      "labels": ["dependencies", "security"]
-    }
+        "assignees": ["iProdigy", "PhilippHeuer"],
+        "labels": ["dependencies", "security"]
+    },
+    "packageRules": [
+        {
+            "matchPackagePrefixes": ["org.infinispan"],
+            "allowedVersions": "/Final$/"
+        }
+    ]
 }


### PR DESCRIPTION
Renovate should ignore `.Dev` infinispan updates