### PR TITLE
chore: use chore commit type for renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,10 @@
     },
     "packageRules": [
         {
+            "matchPackagePatterns": ["*"],
+            "semanticCommitType": "chore"
+        },
+        {
             "matchPackagePrefixes": ["org.infinispan"],
             "allowedVersions": "/Final$/"
         },


### PR DESCRIPTION
# Changes

- make renovate use `chore(deps): ` instead of `fix(deps): `
