### PR TITLE
chore: avoid infinispan major version bumps for java 8 module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
             "allowedVersions": "/Final$/"
         },
         {
+            "matchPackageNames": ["org.infinispan:infinispan-bom"],
+            "matchPaths": ["provider-infinispan/build.gradle.kts"],
+            "allowedVersions": "/^13\\./"
+        },
+        {
             "matchPackageNames": ["com.github.ben-manes.caffeine:caffeine"],
             "matchPaths": ["provider-caffeine/build.gradle.kts"],
             "allowedVersions": "< 3.0.0"


### PR DESCRIPTION
Avoids https://github.com/Xanthic/cache-api/pull/133/commits/2cfd5e7441279cb5c4882a98446acbcda02105fa
