### PR TITLE
chore: bump xanthic to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ repositories {
 }
 
 dependencies {
-    api(platform("io.github.xanthic.cache:cache-bom:0.2.0")) // Specify the latest version here
+    api(platform("io.github.xanthic.cache:cache-bom:0.3.0")) // Specify the latest version here
     api(group = "io.github.xanthic.cache", name = "cache-core") // For library devs
     implementation(group = "io.github.xanthic.cache", name = "cache-provider-caffeine") // For application devs; can select any provider
 }
@@ -78,7 +78,7 @@ dependencies {
             <groupId>io.github.xanthic.cache</groupId>
             <artifactId>cache-bom</artifactId>
             <!-- Specify the latest version here -->
-            <version>0.2.0</version>
+            <version>0.3.0</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ allprojects {
     }
 
     group = "io.github.xanthic.cache"
-    version = "0.2.0"
+    version = "0.3.0"
 }
 
 subprojects {


### PR DESCRIPTION
### What's Changed

* perf(spring): avoid lock contention when obtaining cache in https://togithub.com/Xanthic/cache-api/pull/109
* feat: add infinispan java 11 module in https://togithub.com/Xanthic/cache-api/pull/132
* feat: add spring java 17 module in https://togithub.com/Xanthic/cache-api/pull/135

&nbsp;

Will require new docs pages
