### PR TITLE
feat(api): add forEach method to Cache interface

### DIFF
--- a/api/src/main/java/io/github/xanthic/cache/api/Cache.java
+++ b/api/src/main/java/io/github/xanthic/cache/api/Cache.java
@@ -189,7 +189,7 @@ public interface Cache<K, V> {
 	 * @throws NullPointerException if the specified action is null
 	 */
 	@ApiStatus.Experimental
-	default void forEach(@NotNull BiConsumer<@NotNull K, @NotNull V> action) {
+	default void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/api/src/main/java/io/github/xanthic/cache/api/Cache.java
+++ b/api/src/main/java/io/github/xanthic/cache/api/Cache.java
@@ -187,6 +187,7 @@ public interface Cache<K, V> {
 	 * @implNote This can be an inefficient operation that ought to be avoided;
 	 * perhaps your data can be modeled differently to avoid this operation.
 	 * @throws NullPointerException if the specified action is null
+	 * @throws UnsupportedOperationException if the underlying cache provider does not support iteration over entries
 	 */
 	@ApiStatus.Experimental
 	default void forEach(@NotNull BiConsumer<? super K, ? super V> action) {

--- a/api/src/main/java/io/github/xanthic/cache/api/Cache.java
+++ b/api/src/main/java/io/github/xanthic/cache/api/Cache.java
@@ -189,7 +189,7 @@ public interface Cache<K, V> {
 	 * @throws NullPointerException if the specified action is null
 	 */
 	@ApiStatus.Experimental
-	default void forEach(@NotNull BiConsumer<K, V> action) {
+	default void forEach(@NotNull BiConsumer<@NotNull K, @NotNull V> action) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/api/src/main/java/io/github/xanthic/cache/api/Cache.java
+++ b/api/src/main/java/io/github/xanthic/cache/api/Cache.java
@@ -1,9 +1,11 @@
 package io.github.xanthic.cache.api;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -172,6 +174,23 @@ public interface Cache<K, V> {
 	 */
 	default void putAll(@NotNull Map<? extends K, ? extends V> map) {
 		map.forEach(this::put);
+	}
+
+	/**
+	 * Performs the specified action upon all entries within the cache.
+	 *
+	 * @param action the action to perform upon each entry
+	 * @apiNote While this method is technically optional, all of the canonical
+	 * implementations provided by Xanthic support this operation.
+	 * @implSpec The iteration order of entries is not consistent (across cache different implementations),
+	 * and should not be relied upon. Iteration may terminate early if the action yields an exception.
+	 * @implNote This can be an inefficient operation that ought to be avoided;
+	 * perhaps your data can be modeled differently to avoid this operation.
+	 * @throws NullPointerException if the specified action is null
+	 */
+	@ApiStatus.Experimental
+	default void forEach(@NotNull BiConsumer<K, V> action) {
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -94,4 +95,8 @@ public final class EmptyCache<K, V> implements Cache<K, V> {
 		// no-op
 	}
 
+	@Override
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
+		// no-op
+	}
 }

--- a/core/src/main/java/io/github/xanthic/cache/core/delegate/GenericMapCacheDelegate.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/delegate/GenericMapCacheDelegate.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -87,5 +88,10 @@ public class GenericMapCacheDelegate<K, V> implements Cache<K, V> {
 	@Override
 	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
 		this.map.putAll(map);
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		this.map.forEach(action);
 	}
 }

--- a/core/src/main/java/io/github/xanthic/cache/core/delegate/GenericMapCacheDelegate.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/delegate/GenericMapCacheDelegate.java
@@ -91,7 +91,7 @@ public class GenericMapCacheDelegate<K, V> implements Cache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		this.map.forEach(action);
 	}
 }

--- a/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
+++ b/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
@@ -136,6 +136,30 @@ public abstract class ProviderTestBase {
 	}
 
 	@Test
+	@DisplayName("Tests cache forEach")
+	public void iterateTest() {
+		// Build cache
+		Cache<String, Integer> cache = build(null);
+
+		// Add entries
+		for (int i = 0; i < 3; i++) {
+			cache.put(String.valueOf(i), i);
+		}
+
+		// Save output of forEach
+		Map<String, Integer> observed = new HashMap<>();
+		cache.forEach(observed::put);
+
+		// Test that observed contents match expected
+		Map<String, Integer> expected = new HashMap<>();
+		expected.put("0", 0);
+		expected.put("1", 1);
+		expected.put("2", 2);
+
+		Assertions.assertEquals(expected, observed);
+	}
+
+	@Test
 	@DisplayName("Test that cache size constraint is respected")
 	public void sizeEvictionTest() {
 		// Build cache

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 @Value
 @Getter(AccessLevel.PRIVATE)
@@ -99,6 +100,11 @@ class ExpiringLruDelegate<K, V> extends AbstractCache<K, V> {
 	@Override
 	public long size() {
 		return cache.size();
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		cache.snapshot().forEach(action);
 	}
 
 	@NotNull

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
@@ -103,7 +103,7 @@ class ExpiringLruDelegate<K, V> extends AbstractCache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		cache.snapshot().forEach(action);
 	}
 

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
@@ -104,7 +104,14 @@ class ExpiringLruDelegate<K, V> extends AbstractCache<K, V> {
 
 	@Override
 	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
-		cache.snapshot().forEach(action);
+		if (type == ExpiryType.POST_ACCESS) {
+			synchronized (getLock()) {
+				BiConsumer<K, V> markAccessed = this::start;
+				cache.snapshot().forEach(markAccessed.andThen(action));
+			}
+		} else {
+			cache.snapshot().forEach(action);
+		}
 	}
 
 	@NotNull

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
@@ -43,7 +43,7 @@ class LruDelegate<K, V> extends AbstractCache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		cache.snapshot().forEach(action);
 	}
 

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.BiConsumer;
+
 @Value
 @Getter(AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = false)
@@ -38,6 +40,11 @@ class LruDelegate<K, V> extends AbstractCache<K, V> {
 	@Override
 	public long size() {
 		return cache.size();
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		cache.snapshot().forEach(action);
 	}
 
 	@NotNull

--- a/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kDelegate.java
+++ b/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kDelegate.java
@@ -61,7 +61,7 @@ class Cache2kDelegate<K, V> extends GenericMapCacheDelegate<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		cache.entries().forEach(e -> action.accept(e.getKey(), e.getValue()));
 	}
 }

--- a/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kDelegate.java
+++ b/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kDelegate.java
@@ -7,6 +7,7 @@ import org.cache2k.Cache;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 @Value
@@ -59,4 +60,8 @@ class Cache2kDelegate<K, V> extends GenericMapCacheDelegate<K, V> {
 		cache.putAll(map);
 	}
 
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		cache.entries().forEach(e -> action.accept(e.getKey(), e.getValue()));
+	}
 }

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
@@ -6,6 +6,7 @@ import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -63,5 +64,15 @@ public class EhcacheDelegate<K, V> extends LockedAbstractCache<K, V> {
 	@Override
 	public boolean replace(@NotNull K key, @NotNull V oldValue, @NotNull V newValue) {
 		return read(() -> cache.replace(key, oldValue, newValue));
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		// We can't guarantee that users won't attempt to mutate the cache from within the action
+		// So, we incur a performance penalty to acquire a write (rather than read) lock in order to avoid deadlocking
+		write(() -> {
+			cache.forEach(e -> action.accept((K) e.getKey(), (V) e.getValue()));
+			return Void.TYPE;
+		});
 	}
 }

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
@@ -67,7 +67,7 @@ public class EhcacheDelegate<K, V> extends LockedAbstractCache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		// We can't guarantee that users won't attempt to mutate the cache from within the action
 		// So, we incur a performance penalty to acquire a write (rather than read) lock in order to avoid deadlocking
 		write(() -> {

--- a/provider-infinispan-java11/src/main/java/io/github/xanthic/cache/provider/infinispanjdk11/InfinispanDelegate.java
+++ b/provider-infinispan-java11/src/main/java/io/github/xanthic/cache/provider/infinispanjdk11/InfinispanDelegate.java
@@ -81,7 +81,7 @@ class InfinispanDelegate<K, V> implements Cache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		cache.forEach(action);
 	}
 }

--- a/provider-infinispan-java11/src/main/java/io/github/xanthic/cache/provider/infinispanjdk11/InfinispanDelegate.java
+++ b/provider-infinispan-java11/src/main/java/io/github/xanthic/cache/provider/infinispanjdk11/InfinispanDelegate.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -77,5 +78,10 @@ class InfinispanDelegate<K, V> implements Cache<K, V> {
 	@Override
 	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
 		cache.putAll(map);
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		cache.forEach(action);
 	}
 }

--- a/provider-infinispan/src/main/java/io/github/xanthic/cache/provider/infinispan/InfinispanDelegate.java
+++ b/provider-infinispan/src/main/java/io/github/xanthic/cache/provider/infinispan/InfinispanDelegate.java
@@ -81,7 +81,7 @@ class InfinispanDelegate<K, V> implements Cache<K, V> {
 	}
 
 	@Override
-	public void forEach(@NotNull BiConsumer<K, V> action) {
+	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
 		cache.forEach(action);
 	}
 }

--- a/provider-infinispan/src/main/java/io/github/xanthic/cache/provider/infinispan/InfinispanDelegate.java
+++ b/provider-infinispan/src/main/java/io/github/xanthic/cache/provider/infinispan/InfinispanDelegate.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -77,5 +78,10 @@ class InfinispanDelegate<K, V> implements Cache<K, V> {
 	@Override
 	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
 		cache.putAll(map);
+	}
+
+	@Override
+	public void forEach(@NotNull BiConsumer<K, V> action) {
+		cache.forEach(action);
 	}
 }


### PR DESCRIPTION
Currently experimental/optional - in 1.0.0, we can decide whether to promote to stable/required

Required for upcoming jackson module since https://github.com/FasterXML/jackson-databind/pull/4114 / https://github.com/FasterXML/jackson-databind/blob/2.16/src/main/java/com/fasterxml/jackson/databind/ser/impl/ReadOnlyClassToSerializerMap.java#L30
