### PR TITLE
fix(core): allow zero max size caches across providers

### DIFF
--- a/core/src/main/java/io/github/xanthic/cache/core/CacheApi.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/CacheApi.java
@@ -4,7 +4,9 @@ import io.github.xanthic.cache.api.Cache;
 import io.github.xanthic.cache.api.ICacheSpec;
 import io.github.xanthic.cache.api.exception.MisconfiguredCacheException;
 import io.github.xanthic.cache.api.exception.NoDefaultCacheImplementationException;
+import io.github.xanthic.cache.core.delegate.EmptyCache;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 /**
@@ -32,7 +34,14 @@ public final class CacheApi {
 	 */
 	public static <K, V> Cache<K, V> create(Consumer<CacheApiSpec<K, V>> spec) {
 		CacheApiSpec<K, V> finalSpec = CacheApiSpec.process(spec);
+		if (isPermanentlyEmpty(finalSpec)) return EmptyCache.get();
 		return finalSpec.provider().build(finalSpec);
+	}
+
+	private static boolean isPermanentlyEmpty(ICacheSpec<?, ?> spec) {
+		Long maxSize = spec.maxSize();
+		Duration expiryTime = spec.expiryTime();
+		return (maxSize != null && maxSize == 0) || (expiryTime != null && expiryTime.isZero());
 	}
 
 }

--- a/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
@@ -1,0 +1,97 @@
+package io.github.xanthic.cache.core.delegate;
+
+import io.github.xanthic.cache.api.Cache;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public final class EmptyCache<K, V> implements Cache<K, V> {
+
+	@SuppressWarnings("rawtypes")
+	private static final Cache INSTANCE = new EmptyCache<>();
+
+	@ApiStatus.Internal
+	@SuppressWarnings("unchecked")
+	public static <K, V> Cache<K, V> get() {
+		return INSTANCE;
+	}
+
+	private EmptyCache() {
+		// restrict instantiation
+	}
+
+	@Override
+	public @Nullable V get(@NotNull K key) {
+		return null;
+	}
+
+	@Override
+	public @Nullable V put(@NotNull K key, @NotNull V value) {
+		return null;
+	}
+
+	@Override
+	public @Nullable V remove(@NotNull K key) {
+		return null;
+	}
+
+	@Override
+	public void clear() {
+		// no-op
+	}
+
+	@Override
+	public long size() {
+		return 0L;
+	}
+
+	@Override
+	public @Nullable V compute(@NotNull K key, @NotNull BiFunction<? super K, ? super V, ? extends V> computeFunc) {
+		return null;
+	}
+
+	@Override
+	public V computeIfAbsent(@NotNull K key, @NotNull Function<K, V> computeFunc) {
+		return null;
+	}
+
+	@Override
+	public @Nullable V computeIfPresent(@NotNull K key, @NotNull BiFunction<? super K, ? super V, ? extends V> computeFunc) {
+		return null;
+	}
+
+	@Override
+	public @Nullable V putIfAbsent(@NotNull K key, @NotNull V value) {
+		return null;
+	}
+
+	@Override
+	public V merge(@NotNull K key, @NotNull V value, @NotNull BiFunction<V, V, V> mergeFunc) {
+		return null;
+	}
+
+	@Override
+	public boolean replace(@NotNull K key, @NotNull V value) {
+		return false;
+	}
+
+	@Override
+	public boolean replace(@NotNull K key, @NotNull V oldValue, @NotNull V newValue) {
+		return false;
+	}
+
+	@Override
+	public @NotNull V getOrDefault(@NotNull K key, @NotNull V defaultValue) {
+		return defaultValue;
+	}
+
+	@Override
+	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
+		// no-op
+	}
+
+}

--- a/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/delegate/EmptyCache.java
@@ -51,12 +51,12 @@ public final class EmptyCache<K, V> implements Cache<K, V> {
 
 	@Override
 	public @Nullable V compute(@NotNull K key, @NotNull BiFunction<? super K, ? super V, ? extends V> computeFunc) {
-		return null;
+		return computeFunc.apply(key, null);
 	}
 
 	@Override
 	public V computeIfAbsent(@NotNull K key, @NotNull Function<K, V> computeFunc) {
-		return null;
+		return computeFunc.apply(key);
 	}
 
 	@Override
@@ -71,7 +71,7 @@ public final class EmptyCache<K, V> implements Cache<K, V> {
 
 	@Override
 	public V merge(@NotNull K key, @NotNull V value, @NotNull BiFunction<V, V, V> mergeFunc) {
-		return null;
+		return value;
 	}
 
 	@Override

--- a/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
+++ b/core/src/testFixtures/java/io/github/xanthic/cache/core/provider/ProviderTestBase.java
@@ -136,6 +136,24 @@ public abstract class ProviderTestBase {
 	}
 
 	@Test
+	@DisplayName("Test that caches with zero maximum size remain empty")
+	public void zeroMaxSizeTest() {
+		Cache<String, Integer> cache = build(spec -> spec.maxSize(0L));
+		cache.put("1", 1);
+		Assertions.assertNull(cache.get("1"));
+		Assertions.assertEquals(0, cache.size());
+	}
+
+	@Test
+	@DisplayName("Test that caches with zero time-to-live for entries remain empty")
+	public void zeroExpiryTimeTest() {
+		Cache<String, Integer> cache = build(spec -> spec.expiryTime(Duration.ZERO));
+		cache.put("1", 1);
+		Assertions.assertNull(cache.get("1"));
+		Assertions.assertEquals(0, cache.size());
+	}
+
+	@Test
 	@DisplayName("Test that cache size constraint is respected")
 	public void sizeEvictionTest() {
 		// Build cache


### PR DESCRIPTION
Some users may do `maxSize(0L)` or `expiryTime(Duration.ZERO)` to "disable" caching.

However, this is not supported by all of the underlying providers: https://togithub.com/FasterXML/jackson-databind/pull/4115#discussion_r1335062530

This PR returns `EmptyCache.INSTANCE` in these scenarios to avoid exceptions/inconsistency across providers.
