### PR TITLE
fix(cache2k): create unbounded cache if maxSize is not specified

### DIFF
--- a/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kProvider.java
+++ b/provider-cache2k/src/main/java/io/github/xanthic/cache/provider/cache2k/Cache2kProvider.java
@@ -35,7 +35,13 @@ public final class Cache2kProvider extends AbstractCacheProvider {
 		Cache2kBuilder<K, V> builder = (Cache2kBuilder<K, V>) Cache2kBuilder.forUnknownTypes()
 			.disableStatistics(true); // avoid performance penalty since we don't offer an interface for these statistics
 
-		if (spec.maxSize() != null) builder.entryCapacity(spec.maxSize());
+		if (spec.maxSize() != null) {
+			builder.entryCapacity(spec.maxSize());
+		} else {
+			// We must specify MAX_VALUE to create an unbounded cache to comply with the Xanthic maxSize spec
+			// since Cache2k, by default, imposes a capacity bound of 1802 (Cache2kConfig#DEFAULT_ENTRY_CAPACITY)
+			builder.entryCapacity(Long.MAX_VALUE);
+		}
 
 		ScheduledExecutorService exec = populateExecutor(builder, spec.executor());
 


### PR DESCRIPTION
When `ICacheSpec#maxSize` yields null, an unbounded cache should be created. By default, cache2k imposes an `entryCapacity` of [1802](https://cache2k.org/docs/latest/apidocs/cache2k-api/org/cache2k/config/Cache2kConfig.html#DEFAULT_ENTRY_CAPACITY) (rather than creating an unbounded cache). As a result, we specify `Long.MAX_VALUE` to create an unbounded cache when `maxSize` is null, in accordance to the Xanthic spec.

https://cache2k.org/docs/latest/apidocs/cache2k-api/org/cache2k/Cache2kBuilder.html#entryCapacity(long)
