### PR TITLE
perf(ehcache): avoid coarse locking

### DIFF
--- a/core/src/main/java/io/github/xanthic/cache/core/LockedAbstractCache.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/LockedAbstractCache.java
@@ -27,7 +27,9 @@ import java.util.function.Supplier;
  *
  * @param <K> The type of keys that form the cache
  * @param <V> The type of values contained in the cache
+ * @deprecated no longer used by Xanthic to implement any canonical cache provider
  */
+@Deprecated
 public abstract class LockedAbstractCache<K, V> implements Cache<K, V> {
 
 	protected final ReadWriteLock lock = new ReentrantReadWriteLock();

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
@@ -1,78 +1,177 @@
 package io.github.xanthic.cache.provider.ehcache;
 
-import io.github.xanthic.cache.core.LockedAbstractCache;
-import lombok.EqualsAndHashCode;
+import io.github.xanthic.cache.api.Cache;
 import lombok.Value;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @Value
-@EqualsAndHashCode(callSuper = false)
+@ApiStatus.Internal
 @SuppressWarnings("unchecked")
-public class EhcacheDelegate<K, V> extends LockedAbstractCache<K, V> {
+public class EhcacheDelegate<K, V> implements Cache<K, V> {
 	org.ehcache.Cache<Object, Object> cache;
 
 	@Override
-	protected V getUnlocked(@NotNull K key) {
+	public @Nullable V get(@NotNull K key) {
 		return (V) cache.get(key);
 	}
 
 	@Override
-	protected void putUnlocked(@NotNull K key, @NotNull V value) {
-		cache.put(key, value);
+	public @Nullable V put(@NotNull K key, @NotNull V value) {
+		while (true) {
+			Object prev = cache.get(key);
+			if (prev == null) {
+				if (cache.putIfAbsent(key, value) == null) {
+					return null;
+				}
+			} else {
+				if (cache.replace(key, prev, value)) {
+					return (V) prev;
+				}
+			}
+		}
 	}
 
 	@Override
-	protected void removeUnlocked(@NotNull K key) {
-		cache.remove(key);
+	public @Nullable V remove(@NotNull K key) {
+		while (true) {
+			Object prev = cache.get(key);
+			if (prev == null) {
+				return null;
+			}
+
+			if (cache.remove(key, prev)) {
+				return (V) prev;
+			}
+		}
 	}
 
 	@Override
-	protected void clearUnlocked() {
+	public void clear() {
 		cache.clear();
 	}
 
 	@Override
-	protected long sizeUnlocked() {
-		long n = 0;
-		for (org.ehcache.Cache.Entry<Object, Object> ignored : cache) {
-			n++;
+	public long size() {
+		// TODO: use statistics
+		LongAdder l = new LongAdder();
+		cache.forEach(e -> l.increment());
+		return l.sum();
+	}
+
+	@Override
+	public @Nullable V compute(@NotNull K key, @NotNull BiFunction<? super K, ? super V, ? extends V> computeFunc) {
+		while (true) {
+			Object old = cache.get(key);
+			V computed = computeFunc.apply(key, (V) old);
+			if (computed == null) {
+				if (old == null || cache.remove(key, old)) {
+					return null;
+				}
+			} else {
+				if (old == null) {
+					if (cache.putIfAbsent(key, computed) == null) {
+						return computed;
+					}
+				} else {
+					if (cache.replace(key, old, computed)) {
+						return computed;
+					}
+				}
+			}
 		}
-		return n;
 	}
 
 	@Override
-	public V putIfAbsent(@NotNull K key, @NotNull V value) {
-		return read(() -> (V) cache.putIfAbsent(key, value));
+	public V computeIfAbsent(@NotNull K key, @NotNull Function<K, V> computeFunc) {
+		Object initial = cache.get(key);
+		if (initial != null) {
+			return (V) initial;
+		}
+
+		V computed = computeFunc.apply(key);
+		if (computed == null) {
+			return null;
+		}
+
+		Object previous = cache.putIfAbsent(key, computed);
+		if (previous == null) {
+			return computed;
+		} else {
+			return (V) previous;
+		}
 	}
 
 	@Override
-	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
-		read(() -> {
-			cache.putAll(map);
-			return Void.TYPE;
-		});
+	public @Nullable V computeIfPresent(@NotNull K key, @NotNull BiFunction<? super K, ? super V, ? extends V> computeFunc) {
+		while (true) {
+			Object oldValue = cache.get(key);
+			if (oldValue == null) {
+				return null;
+			}
+			V computed = computeFunc.apply(key, (V) oldValue);
+			if (computed == null) {
+				if (cache.remove(key, oldValue))
+					return null;
+			} else {
+				if (cache.replace(key, oldValue, computed)) {
+					return computed;
+				}
+			}
+		}
+	}
+
+	@Override
+	public @Nullable V putIfAbsent(@NotNull K key, @NotNull V value) {
+		return (V) cache.putIfAbsent(key, value);
+	}
+
+	@Override
+	public V merge(@NotNull K key, @NotNull V value, @NotNull BiFunction<V, V, V> mergeFunc) {
+		Object oldValue = cache.get(key);
+		while (true) {
+			if (oldValue == null) {
+				Object latest = cache.putIfAbsent(key, value);
+				if (latest == null) {
+					return value;
+				} else {
+					oldValue = latest;
+				}
+			} else {
+				V merged = mergeFunc.apply((V) oldValue, value);
+				if (cache.replace(key, oldValue, merged)) {
+					return merged;
+				} else {
+					oldValue = cache.get(key);
+				}
+			}
+		}
 	}
 
 	@Override
 	public boolean replace(@NotNull K key, @NotNull V value) {
-		return read(() -> cache.replace(key, value) != null);
+		return cache.replace(key, value) != null;
 	}
 
 	@Override
 	public boolean replace(@NotNull K key, @NotNull V oldValue, @NotNull V newValue) {
-		return read(() -> cache.replace(key, oldValue, newValue));
+		return cache.replace(key, oldValue, newValue);
+	}
+
+	@Override
+	public void putAll(@NotNull Map<? extends K, ? extends V> map) {
+		cache.putAll(map);
 	}
 
 	@Override
 	public void forEach(@NotNull BiConsumer<? super K, ? super V> action) {
-		// We can't guarantee that users won't attempt to mutate the cache from within the action
-		// So, we incur a performance penalty to acquire a write (rather than read) lock in order to avoid deadlocking
-		write(() -> {
-			cache.forEach(e -> action.accept((K) e.getKey(), (V) e.getValue()));
-			return Void.TYPE;
-		});
+		cache.forEach(e -> action.accept((K) e.getKey(), (V) e.getValue()));
 	}
 }

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
@@ -60,7 +60,6 @@ public class EhcacheDelegate<K, V> implements Cache<K, V> {
 
 	@Override
 	public long size() {
-		// TODO: use statistics
 		LongAdder l = new LongAdder();
 		cache.forEach(e -> l.increment());
 		return l.sum();

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheDelegate.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -60,9 +59,11 @@ public class EhcacheDelegate<K, V> implements Cache<K, V> {
 
 	@Override
 	public long size() {
-		LongAdder l = new LongAdder();
-		cache.forEach(e -> l.increment());
-		return l.sum();
+		long n = 0;
+		for (org.ehcache.Cache.Entry<Object, Object> ignored : cache) {
+			n++;
+		}
+		return n;
 	}
 
 	@Override

--- a/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheProvider.java
+++ b/provider-ehcache/src/main/java/io/github/xanthic/cache/provider/ehcache/EhcacheProvider.java
@@ -13,6 +13,7 @@ import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.core.spi.time.TickingTimeSource;
 import org.ehcache.event.EventType;
+import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.internal.TimeSourceConfiguration;
 
 import java.time.Duration;
@@ -46,12 +47,16 @@ public final class EhcacheProvider extends AbstractCacheProvider {
 			)
 		};
 
-		handleExpiration(spec.expiryTime(), spec.expiryType(), (time, type) -> {
-			if (type == ExpiryType.POST_WRITE)
-				builder[0] = builder[0].withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(time));
-			else
-				builder[0] = builder[0].withExpiry(ExpiryPolicyBuilder.timeToIdleExpiration(time));
-		});
+		if (spec.expiryTime() == null) {
+			builder[0].withExpiry(ExpiryPolicy.NO_EXPIRY);
+		} else {
+			handleExpiration(spec.expiryTime(), spec.expiryType(), (time, type) -> {
+				if (type == ExpiryType.POST_WRITE)
+					builder[0] = builder[0].withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(time));
+				else
+					builder[0] = builder[0].withExpiry(ExpiryPolicyBuilder.timeToIdleExpiration(time));
+			});
+		}
 
 		if (spec.removalListener() != null) {
 			builder[0] = builder[0].withService(


### PR DESCRIPTION
Rewrites EhcacheDelegate without `ReadWriteLock` - achieves 10x throughput in certain multi-threaded benchmarks
