### PR TITLE
chore: enable reproducible archives

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,12 @@ subprojects {
                 }
             }
 
+            // reproducible builds
+            withType<AbstractArchiveTask>().configureEach {
+                isPreserveFileTimestamps = false
+                isReproducibleFileOrder = true
+            }
+
             // testing
             test {
                 useJUnitPlatform()


### PR DESCRIPTION
sets the properties to enable reproducible builds, see https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives

we can try to set this up with https://github.com/jvm-repo-rebuild/reproducible-central / https://reproducible-builds.org/ for the next release.