### PR TITLE
feat(spring): implement optional cache methods

### DIFF
--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -57,6 +57,11 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	}
 
 	@Override
+	public ValueWrapper putIfAbsent(@NotNull Object key, Object value) {
+		return toValueWrapper(cache.putIfAbsent(key, toStoreValue(value)));
+	}
+
+	@Override
 	public void evict(@NotNull Object key) {
 		cache.remove(key);
 	}

--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -62,6 +62,11 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	}
 
 	@Override
+	public boolean evictIfPresent(@NotNull Object key) {
+		return cache.remove(key) != null;
+	}
+
+	@Override
 	public void clear() {
 		cache.clear();
 	}

--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -85,7 +85,7 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	public CompletableFuture<?> retrieve(@NotNull Object key) {
 		Object value = lookup(key);
 		if (value == null) return null;
-		return CompletableFuture.completedFuture(fromStoreValue(value));
+		return CompletableFuture.completedFuture(toValueWrapper(value));
 	}
 
 	@NotNull

--- a/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/SpringCacheTest.java
+++ b/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/SpringCacheTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,7 @@ public class SpringCacheTest {
 	CacheManager cacheManager;
 
 	@Test
-	@DisplayName("Tests cache get, put, putIfAbsent, clear")
+	@DisplayName("Tests cache get, put, putIfAbsent, retrieve, clear")
 	public void putGetClearTest() {
 		Cache cache = Objects.requireNonNull(cacheManager.getCache("dev"));
 
@@ -42,6 +43,16 @@ public class SpringCacheTest {
 		// Test putIfAbsent
 		Assertions.assertEquals(420, Objects.requireNonNull(cache.putIfAbsent("4/20", 69)).get());
 		Assertions.assertEquals(420, Objects.requireNonNull(cache.get("4/20")).get());
+
+		// Test retrieve
+		Assertions.assertEquals(420, Objects.requireNonNull(cache.retrieve("4/20")).join());
+		CompletableFuture<?> missing = cache.retrieve("8/21");
+		Assertions.assertTrue(missing == null || missing.join() == null);
+		cache.put("5/11", null);
+		Assertions.assertNull(Objects.requireNonNull(cache.retrieve("5/11")).join());
+		Assertions.assertNull(Objects.requireNonNull(cache.retrieve("5/11", () -> CompletableFuture.completedFuture(1605))).join());
+		Assertions.assertEquals(69, cache.retrieve("6/9", () -> CompletableFuture.supplyAsync(() -> 69)).join());
+		Assertions.assertEquals(69, cache.retrieve("6/9", () -> CompletableFuture.supplyAsync(() -> 70)).join());
 
 		// Test clear
 		cache.clear();

--- a/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
+++ b/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
@@ -55,6 +55,11 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	}
 
 	@Override
+	public ValueWrapper putIfAbsent(@NotNull Object key, Object value) {
+		return toValueWrapper(cache.putIfAbsent(key, toStoreValue(value)));
+	}
+
+	@Override
 	public void evict(@NotNull Object key) {
 		cache.remove(key);
 	}

--- a/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
+++ b/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
@@ -60,6 +60,11 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	}
 
 	@Override
+	public boolean evictIfPresent(@NotNull Object key) {
+		return cache.remove(key) != null;
+	}
+
+	@Override
 	public void clear() {
 		cache.clear();
 	}


### PR DESCRIPTION
* Implement new `CompletableFuture` versions of lookup that were added to the Cache interface in spring context v6.1,
* Explicitly implement `evictIfPresent` so the return value contains more information (previously would always return false)
* Explicitly implement `putIfAbsent` so the operation is atomic (default impl is non-atomic)
