### PR TITLE
fix(spring): ensure cache names are unique

### DIFF
--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCacheManager.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCacheManager.java
@@ -49,7 +49,7 @@ public class XanthicSpringCacheManager implements CacheManager {
 		if (cacheNames != null) {
 			this.dynamic = false;
 			for (String name : cacheNames) {
-				this.cacheMap.put(name, createCache(name, this.spec));
+				this.cacheMap.computeIfAbsent(name, s -> createCache(s, this.spec));
 			}
 		} else {
 			this.dynamic = true;
@@ -77,12 +77,16 @@ public class XanthicSpringCacheManager implements CacheManager {
 	 *
 	 * @param name the name of the cache
 	 * @param spec configuration for the specified cache
+	 * @throws IllegalStateException if the cache manager is not in dynamic mode or a cache with the same name was already registered
 	 */
 	public void registerCache(String name, Consumer<CacheApiSpec<Object, Object>> spec) {
 		if (!this.dynamic) throw new IllegalStateException("CacheManager has a fixed set of cache keys and does not allow creation of new caches.");
 
-		this.cacheMap.put(name, createCache(name, spec));
-		this.customCacheNames.add(name);
+		if (this.customCacheNames.add(name)) {
+			this.cacheMap.put(name, createCache(name, spec));
+		} else {
+			throw new IllegalStateException("CacheManager already has a cache registered with the name: " + name);
+		}
 	}
 
 	private Cache createCache(String name, Consumer<CacheApiSpec<Object, Object>> spec) {

--- a/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/SpringCacheTest.java
+++ b/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/SpringCacheTest.java
@@ -126,10 +126,10 @@ public class SpringCacheTest {
 	@DisplayName("Tests the eviction of entries based on max size")
 	public void valueLoaderConcurrentTest() throws InterruptedException {
 		XanthicSpringCacheManager xanthicSpringCacheManager = (XanthicSpringCacheManager) cacheManager;
-		xanthicSpringCacheManager.registerCache("value-cache", spec -> {
+		xanthicSpringCacheManager.registerCache("value-cache-concurrent", spec -> {
 			spec.maxSize(100L);
 		});
-		Cache cache = Objects.requireNonNull(cacheManager.getCache("value-cache"));
+		Cache cache = Objects.requireNonNull(cacheManager.getCache("value-cache-concurrent"));
 
 		AtomicInteger callCounter = new AtomicInteger(0);
 		Callable<String> valueLoader = () -> {

--- a/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/config/CacheConfiguration.java
+++ b/spring-java17/src/test/java/io/github/xanthic/cache/springjdk17/config/CacheConfiguration.java
@@ -11,13 +11,9 @@ public class CacheConfiguration {
 
 	@Bean
 	public CacheManager cacheManager() {
-		XanthicSpringCacheManager cacheManager = new XanthicSpringCacheManager(spec -> {
+        return new XanthicSpringCacheManager(spec -> {
 			spec.expiryType(ExpiryType.POST_ACCESS);
 		});
-		cacheManager.registerCache("my-custom-cache", spec -> {
-			spec.maxSize(10L);
-		});
-		return cacheManager;
 	}
 
 }

--- a/spring/src/test/java/io/github/xanthic/cache/spring/SpringCacheTest.java
+++ b/spring/src/test/java/io/github/xanthic/cache/spring/SpringCacheTest.java
@@ -113,10 +113,10 @@ public class SpringCacheTest {
 	@DisplayName("Tests the eviction of entries based on max size")
 	public void valueLoaderConcurrentTest() throws InterruptedException {
 		XanthicSpringCacheManager xanthicSpringCacheManager = (XanthicSpringCacheManager) cacheManager;
-		xanthicSpringCacheManager.registerCache("value-cache", spec -> {
+		xanthicSpringCacheManager.registerCache("value-cache-concurrent", spec -> {
 			spec.maxSize(100L);
 		});
-		Cache cache = Objects.requireNonNull(cacheManager.getCache("value-cache"));
+		Cache cache = Objects.requireNonNull(cacheManager.getCache("value-cache-concurrent"));
 
 		AtomicInteger callCounter = new AtomicInteger(0);
 		Callable<String> valueLoader = () -> {

--- a/spring/src/test/java/io/github/xanthic/cache/spring/config/CacheConfiguration.java
+++ b/spring/src/test/java/io/github/xanthic/cache/spring/config/CacheConfiguration.java
@@ -11,14 +11,9 @@ public class CacheConfiguration {
 
 	@Bean
 	public CacheManager cacheManager() {
-		XanthicSpringCacheManager cacheManager = new XanthicSpringCacheManager(spec -> {
+        return new XanthicSpringCacheManager(spec -> {
 			spec.expiryType(ExpiryType.POST_ACCESS);
 		});
-		cacheManager.registerCache("my-custom-cache", spec -> {
-			spec.maxSize(10L);
-		});
-
-		return cacheManager;
 	}
 
 }


### PR DESCRIPTION
Prevents hard-to-debug behavior if a user accidentally registers multiple caches with the same name
