### PR TITLE
chore: utilize conditional signing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ subprojects {
     }
 
     signing {
+        isRequired = false // only sign when credentials are configured
         useGpgCmd()
         sign(publishing.publications["main"])
     }


### PR DESCRIPTION
Since [Reproducible Central](https://github.com/jvm-repo-rebuild/reproducible-central/) doesn't have GPG creds to sign the main publication, build failures occur when trying to publish to maven local (even with `-x signMainPublication`). 

Instead, we can skip signing if creds are absent: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:conditional_signing
