### PR TITLE
chore: pin gh action versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         java-version: '17'
         distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      uses: gradle/actions/setup-gradle@750cdda3edd6d51b7fdfc069d2e2818cf3c44f4c # v3.3.1
       with:
         arguments: build


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v4.1.3
https://github.com/actions/setup-java/releases/tag/v4.2.1
https://github.com/gradle/actions/releases/tag/v3.3.1 (updated from [v2.2.1](https://github.com/gradle/gradle-build-action/releases/tag/v2.2.1))
