### PR TITLE
fix(spring): improve null safety for cache get with loader

### DIFF
--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -31,17 +31,17 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T get(@NotNull Object key, @NotNull Callable<T> valueLoader) {
-		return (T) cache.computeIfAbsent(key, k -> getSynchronized(key, valueLoader));
+		return (T) fromStoreValue(cache.computeIfAbsent(key, k -> getSynchronized(key, valueLoader)));
 	}
 
-	private synchronized <T> T getSynchronized(Object key, Callable<T> valueLoader) {
+	private synchronized <T> Object getSynchronized(Object key, Callable<T> valueLoader) {
 		T value;
 		try {
 			value = valueLoader.call();
 		} catch (Exception e) {
 			throw new ValueRetrievalException(key, valueLoader, e);
 		}
-		return value;
+		return toStoreValue(value);
 	}
 
 	@Override

--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -31,17 +31,13 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T get(@NotNull Object key, @NotNull Callable<T> valueLoader) {
-		return (T) fromStoreValue(cache.computeIfAbsent(key, k -> getSynchronized(key, valueLoader)));
-	}
-
-	private synchronized <T> Object getSynchronized(Object key, Callable<T> valueLoader) {
-		T value;
-		try {
-			value = valueLoader.call();
-		} catch (Exception e) {
-			throw new ValueRetrievalException(key, valueLoader, e);
-		}
-		return toStoreValue(value);
+		return (T) fromStoreValue(cache.computeIfAbsent(key, k -> {
+			try {
+				return toStoreValue(valueLoader.call());
+			} catch (Exception e) {
+				throw new ValueRetrievalException(key, valueLoader, e);
+			}
+		}));
 	}
 
 	@Override

--- a/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
+++ b/spring-java17/src/main/java/io/github/xanthic/cache/springjdk17/XanthicSpringCache.java
@@ -34,14 +34,7 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 		return (T) cache.computeIfAbsent(key, k -> getSynchronized(key, valueLoader));
 	}
 
-	@SuppressWarnings("unchecked")
 	private synchronized <T> T getSynchronized(Object key, Callable<T> valueLoader) {
-		ValueWrapper result = get(key);
-
-		if (result != null) {
-			return (T) result.get();
-		}
-
 		T value;
 		try {
 			value = valueLoader.call();

--- a/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
+++ b/spring/src/main/java/io/github/xanthic/cache/spring/XanthicSpringCache.java
@@ -29,24 +29,13 @@ public class XanthicSpringCache extends AbstractValueAdaptingCache {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T get(@NotNull Object key, @NotNull Callable<T> valueLoader) {
-		return (T) cache.computeIfAbsent(key, k -> getSynchronized(key, valueLoader));
-	}
-
-	@SuppressWarnings("unchecked")
-	private synchronized <T> T getSynchronized(Object key, Callable<T> valueLoader) {
-		ValueWrapper result = get(key);
-
-		if (result != null) {
-			return (T) result.get();
-		}
-
-		T value;
-		try {
-			value = valueLoader.call();
-		} catch (Exception e) {
-			throw new ValueRetrievalException(key, valueLoader, e);
-		}
-		return value;
+		return (T) fromStoreValue(cache.computeIfAbsent(key, k -> {
+			try {
+				return toStoreValue(valueLoader.call());
+			} catch (Exception e) {
+				throw new ValueRetrievalException(key, valueLoader, e);
+			}
+		}));
 	}
 
 	@Override


### PR DESCRIPTION
See https://github.com/spring-projects/spring-framework/blob/d2ea5b444812b4c55e00fecb7b6451073677061d/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCache.java#L148-L157 / https://github.com/spring-projects/spring-framework/blob/d2ea5b444812b4c55e00fecb7b6451073677061d/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCache.java#L134-L136

* need `fromStoreValue` in case `NullValue.INSTANCE` is stored
* need `toStoreValue` in case `valueLoader` yields null
* can remove synchronization since most underlying providers already lock the table segment as needed
