### PR TITLE
chore(build): allow signing with pgp or gpg

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,9 @@ subprojects {
 
     signing {
         isRequired = false // only sign when credentials are configured
-        useGpgCmd()
+        if (!project.hasProperty("gnupg.skip")) {
+            useGpgCmd()
+        }
         sign(publishing.publications["main"])
     }
 }


### PR DESCRIPTION
useful for https://github.com/jvm-repo-rebuild/reproducible-central to avoid `signMainPublication > A problem occurred starting process 'command 'gpg''`
