### PR TITLE
chore: deprecate AbstractCache that relies upon synchronization

### DIFF
--- a/core/src/main/java/io/github/xanthic/cache/core/LockedAbstractCache.java
+++ b/core/src/main/java/io/github/xanthic/cache/core/LockedAbstractCache.java
@@ -1,6 +1,7 @@
 package io.github.xanthic.cache.core;
 
 import io.github.xanthic.cache.api.Cache;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +31,7 @@ import java.util.function.Supplier;
  * @deprecated no longer used by Xanthic to implement any canonical cache provider
  */
 @Deprecated
+@ApiStatus.ScheduledForRemoval(inVersion = "1.0.0")
 public abstract class LockedAbstractCache<K, V> implements Cache<K, V> {
 
 	protected final ReadWriteLock lock = new ReentrantReadWriteLock();

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/AbstractCache.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/AbstractCache.java
@@ -1,7 +1,6 @@
-package io.github.xanthic.cache.core;
+package io.github.xanthic.cache.provider.androidx;
 
 import io.github.xanthic.cache.api.Cache;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -9,27 +8,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-/**
- * Provides a common implementation of:
- * <ul>
- *     <li>{@link Cache#computeIfAbsent(Object, Function)}</li>
- *     <li>{@link Cache#putIfAbsent(Object, Object)}</li>
- *     <li>{@link Cache#merge(Object, Object, BiFunction)}</li>
- * </ul>
- * <p>
- * Subclasses ought to synchronize on {@link #getLock()} for correctness.
- * <p>
- * Avoid this abstraction if the backing cache provider already provides an implementation for these methods.
- * <p>
- * Does not support null values.
- *
- * @param <K> The type of keys that form the cache
- * @param <V> The type of values contained in the cache
- * @deprecated no longer used by Xanthic; synchronization generally should be avoided
- */
-@Deprecated
-@ApiStatus.ScheduledForRemoval(inVersion = "1.0.0")
-public abstract class AbstractCache<K, V> implements Cache<K, V> {
+abstract class AbstractCache<K, V> implements Cache<K, V> {
 
 	@Override
 	public V computeIfAbsent(@NotNull K key, @NotNull Function<K, V> computeFunc) {

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/ExpiringLruDelegate.java
@@ -4,7 +4,6 @@ import androidx.collection.LruCache;
 import io.github.xanthic.cache.api.RemovalListener;
 import io.github.xanthic.cache.api.domain.ExpiryType;
 import io.github.xanthic.cache.api.domain.RemovalCause;
-import io.github.xanthic.cache.core.AbstractCache;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
+++ b/provider-androidx/src/main/java/io/github/xanthic/cache/provider/androidx/LruDelegate.java
@@ -1,7 +1,6 @@
 package io.github.xanthic.cache.provider.androidx;
 
 import androidx.collection.LruCache;
-import io.github.xanthic.cache.core.AbstractCache;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;


### PR DESCRIPTION
Caches typically shouldn't use `AbstractCache` due to its use of synchronization (bad for multi-threaded performance and virtual threads pre JEP 8337395)

We only use it for the android module since the underlying LruCache also synchronizes all operations, so I've copied the class to a package-private form for that module
