### PR TITLE
 chore: restore reproducibility of kotlin sources jar 

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -17,6 +17,11 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
 
+tasks.kotlinSourcesJar {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-54207/ in order to restore reproducibility
+    enabled = false
+}
+
 tasks.javadocJar {
     from(tasks.dokkaJavadoc)
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
     kotlin("jvm") version "2.1.0"
     id("org.jetbrains.dokka") version "1.9.20"
@@ -13,8 +16,10 @@ dependencies {
     testImplementation(project(":cache-provider-caffeine"))
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
 }
 
 tasks.kotlinSourcesJar {


### PR DESCRIPTION
See https://github.com/jvm-repo-rebuild/reproducible-central/pull/1363
https://youtrack.jetbrains.com/issue/KT-54207/Kotlin-has-two-sources-tasks-kotlinSourcesJar-and-sourcesJar-that-archives-sources-to-the-same-artifact
https://redirect.github.com/micrometer-metrics/micrometer/issues/5151